### PR TITLE
Change references from z-division to Shopify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Native Go Zookeeper Client Library [![GoDoc](https://godoc.org/github.com/z-division/go-zookeeper?status.svg)](https://godoc.org/github.com/z-division/go-zookeeper/zk)
+# Native Go Zookeeper Client Library [![GoDoc](https://godoc.org/github.com/Shopify/go-zookeeper?status.svg)](https://godoc.org/github.com/Shopify/go-zookeeper/zk)
 
 Package `zk` provides a native client for connecting to a Zookeeper quorum.
 
 This fork incoporates pull requests against the upstream, fixing some key outstanding issues. It also improves support for Zookeeper 3.5 while maintaining a backward-compatible API.
 
-A full list of incorporated pull requests is detailed on the [wiki](https://github.com/z-division/go-zookeeper/wiki).
+A full list of incorporated pull requests is detailed on the [wiki](https://github.com/Shopify/go-zookeeper/wiki).
 
-An [example using this client in a production environment](https://github.com/z-division/go-zookeeper/wiki/Example-Production-Usage)  is listed and annotated on the wiki.
+An [example using this client in a production environment](https://github.com/Shopify/go-zookeeper/wiki/Example-Production-Usage)  is listed and annotated on the wiki.
 
 ## License
 3-clause BSD. See LICENSE file.

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/z-division/go-zookeeper/zk"
+	"github.com/Shopify/go-zookeeper/zk"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/z-division/go-zookeeper
+module github.com/Shopify/go-zookeeper
 
-go 1.13
+go 1.14


### PR DESCRIPTION
Updating the go mod file so this package can be imported.

I updated the go version as well. Its safe to assume this is unused right now. Should I set up CI if I'm bumping the go version?